### PR TITLE
Update to 22.6.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
-{% set version = "22.3.1" %}
-{% set hash = "92811a3a095a2b62e6ef3b027df099e681bfffb606f977fe49fe9c66055dd54e" %}
+{% set version = "22.6.0" %}
+{% set hash = "b266c95d2d955941aec61901fc5959850a8ec1ac9c2cdf5253b5b6d3f44efe12" %}
 {% set build_number = "0" %}
 
 package:
@@ -22,7 +22,7 @@ requirements:
     - flit-core >=3.2,<4
   run:
     - python >=3.6
-    - libmambapy >=0.22.1
+    - libmambapy >=0.23
     - conda >=4.12
     - importlib_metadata
 


### PR DESCRIPTION
This increases the minimum version of libmambapy.