### PR TITLE
Roll build number, remove noarch.

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set version = "22.8.1" %}
 {% set hash = "90d74148ed26dc0e1500f368b0b8b4097f792fe7612f402f05db5f01ec534cdf" %}
-{% set build_number = "0" %}
+{% set build_number = "1" %}
 
 package:
   name: conda-libmamba-solver
@@ -11,8 +11,7 @@ source:
   sha256: {{ hash }}
 
 build:
-  noarch: python
-  number: 0
+  number: {{ build_number }}
   script: "{{ PYTHON }} -m pip install . -vv"
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set version = "22.8.1" %}
 {% set hash = "90d74148ed26dc0e1500f368b0b8b4097f792fe7612f402f05db5f01ec534cdf" %}
-{% set build_number = "1" %}
+{% set build_number = "0" %}
 
 package:
   name: conda-libmamba-solver
@@ -11,6 +11,7 @@ source:
   sha256: {{ hash }}
 
 build:
+  skip: true  # [py<37]
   number: {{ build_number }}
   script: "{{ PYTHON }} -m pip install . -vv"
 
@@ -18,9 +19,11 @@ requirements:
   host:
     - python
     - pip
+    - wheel
+    - setuptools
     - flit-core >=3.2,<4
   run:
-    - python >=3.6
+    - python
     - libmambapy >=0.23
     - conda >=4.13
     - importlib_metadata
@@ -29,8 +32,8 @@ test:
   imports:
     - conda_libmamba_solver
   commands:
-    - CONDA_SOLVER_LOGIC=libmamba conda create -n test --dry-run scipy  # [not win]
-    - conda create --experimental-solver libmamba -n test --dry-run scipy  # [win]
+    # - CONDA_SOLVER_LOGIC=libmamba conda create -n test --dry-run scipy  # [not win]  Not crosss platform.
+    - conda create --experimental-solver libmamba -n test --dry-run scipy
 
 about:
   home: https://github.com/conda-incubator/conda-libmamba-solver
@@ -39,4 +42,4 @@ about:
   license_file: LICENSE
   summary: 'The fast mamba solver, now in conda!'
   dev_url: https://github.com/conda-incubator/conda-libmamba-solver
-  doc_url: https://github.com/conda-incubator/conda-libmamba-solver/README.md
+  doc_url: https://github.com/conda-incubator/conda-libmamba-solver/blob/main/README.md

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -29,7 +29,8 @@ test:
   imports:
     - conda_libmamba_solver
   commands:
-    - CONDA_SOLVER_LOGIC=libmamba conda create -n test --dry-run scipy
+    - CONDA_SOLVER_LOGIC=libmamba conda create -n test --dry-run scipy  # [not win]
+    - conda create --experimental-solver libmamba -n test --dry-run scipy  # [win]
 
 about:
   home: https://github.com/conda-incubator/conda-libmamba-solver


### PR DESCRIPTION
Remove `noarch: python`.
Roll build number.
Fix test for win64