### PR TITLE
conda-libmamba-solver 23.1.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
-{% set version = "22.12.0" %}
-{% set hash = "5efd8a03ebcbe228d7702224855ca6a29045bbc3f9096f7c5fa54c19e8f55760" %}
+{% set version = "23.1.0" %}
+{% set hash = "090070a54572236f8e23263659520a27c31161e595a1c4feaffb70263d86a32e" %}
 {% set build_number = "0" %}
 
 package:
@@ -25,7 +25,7 @@ requirements:
   run:
     - python
     - libmambapy >=1.0.0
-    - conda >=22.11.0
+    - conda >=23.1.0
     - importlib-metadata
 
 test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,7 @@ source:
 build:
   skip: true  # [py<37]
   number: {{ build_number }}
-  script: "{{ PYTHON }} -m pip install . -vv"
+  script: {{ PYTHON }} -m pip install . -vv --no-deps
 
 requirements:
   host:
@@ -41,5 +41,10 @@ about:
   license_family: BSD
   license_file: LICENSE
   summary: 'The fast mamba solver, now in conda!'
+  description: |
+    The conda-libmamba-solver is a new solver for the conda package manager 
+    which uses the solver from the mamba project behind the scenes, 
+    while carefully implementing conda's functionality and expected behaviors on top. 
+    The library used by mamba to do the heavy-lifting is called libsolv.
   dev_url: https://github.com/conda/conda-libmamba-solver
   doc_url: https://conda.github.io/conda-libmamba-solver/

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -25,7 +25,7 @@ requirements:
   run:
     - python
     - libmambapy >=1.0.0
-    - conda >=23.1.0
+    - conda >=22.11.0
     - importlib-metadata
 
 test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -48,3 +48,11 @@ about:
     The library used by mamba to do the heavy-lifting is called libsolv.
   dev_url: https://github.com/conda/conda-libmamba-solver
   doc_url: https://conda.github.io/conda-libmamba-solver/
+
+extra:
+  recipe-maintainers:
+    - jaimergp
+    - jezdez
+    - wolfv
+  skip-lints:
+    - missing_pip_check


### PR DESCRIPTION
https://github.com/conda/conda-libmamba-solver/issues/124

**Jira ticket:** [PKG-1078](https://anaconda.atlassian.net/browse/PKG-1078) (conda-libmamba-solver-23.1.0)

**The upstream data:**
Github releases:  https://github.com/conda/conda-libmamba-solver/releases
[Diff between the latest and previous upstream releases](https://github.com/conda/conda-libmamba-solver/compare/22.12.0...23.1.0)
Changelog: https://github.com/conda/conda-libmamba-solver/blob/main/CHANGELOG.md
License: https://github.com/conda/conda-libmamba-solver/blob/23.1.0/LICENSE
Requirements: https://github.com/conda/conda-libmamba-solver/blob/23.1.0/pyproject.toml

**_Actions:_**

1. Add the flag `--no-deps` to `script`
2. Add a `description`
3. Add `extra` section
4. Add `missing_pip_check` to `skip-lints`

**_Notes:_**
 * **conda-libmamba-solver 23.1.0** depends on libmamba & libmambapy 1.2.0

**Additional info:**

<details>

**Package's statistics**

<details>

 * Priority  | effort:  | Category:  | subcategory:  | pkg_type: 
 * Outdated platfroms: 
 * Latest version: 
 * Popularity: 
    * 3 months downloads: 
    * All time:  81061 downloads -  -libmamba-solver  23.1.0  The fast mamba solver, now in !  copy  

</details>

**Other checks:**

<details>
    
5. - [x] Check the pinnings    
8. - [x] Verify that the `build_number` is correct
9. - [x] has `setuptools`
10. - [x] has `wheel`
11. - [x] NO `pip` in test
    
12. - [x] Verify the test section
13. - [x] Verify if the package is `architecture specific`
14. - [x] Verify that private modules are not mentioned in the recipe For example: (_private_module)
15.  - [x] license_file: LICENSE is present

16. - [x] license_family BSD is present
17. - [x] License: BSD-3-Clause
    - [x] License is `spdx` compliant
 * Check if the license identifier has correct name from the SPDX License List

| Identifier                           |
|:-------------------------------------|
| BSD-3-Clause                         |
| BSD-3-Clause-Attribution             |
| BSD-3-Clause-Clear                   |
| BSD-3-Clause-LBNL                    |
| BSD-3-Clause-Modification            |
| BSD-3-Clause-No-Military-License     |
| BSD-3-Clause-No-Nuclear-License      |
| BSD-3-Clause-No-Nuclear-License-2014 |
| BSD-3-Clause-No-Nuclear-Warranty     |
| BSD-3-Clause-Open-MPI                |
</details>

**Check dependency issues:**

<details>
../aggregate/conda-libmamba-solver-feedstock/recipe/meta.yaml
Dependencies: ['setuptools', 'wheel', 'pip', 'python', 'flit-core >=3.2,<4', 'libmambapy >=1.0.0', 'conda >=22.11.0', 'importlib-metadata']


noarch:
- py3.7:  No issues found
- py3.8:  No issues found
- py3.9:  No issues found
- py3.10:  No issues found

linux-64:
- py3.7:  Encountered problems while solving:
  - nothing provides __glibc >=2.17 needed by libstdcxx-ng-11.2.0-h1234567_0

- py3.8:  Encountered problems while solving:
  - nothing provides __glibc >=2.17 needed by libstdcxx-ng-11.2.0-h1234567_0

- py3.9:  Encountered problems while solving:
  - nothing provides __glibc >=2.17 needed by libstdcxx-ng-11.2.0-h1234567_0

- py3.10:  Encountered problems while solving:
  - nothing provides __glibc >=2.17 needed by libstdcxx-ng-11.2.0-h1234567_0


linux-ppc64le:
- py3.7:  No issues found
- py3.8:  No issues found
- py3.9:  No issues found
- py3.10:  No issues found

linux-s390x:
- py3.7:  No issues found
- py3.8:  No issues found
- py3.9:  No issues found
- py3.10:  No issues found

osx-64:
- py3.7:  No issues found
- py3.8:  No issues found
- py3.9:  No issues found
- py3.10:  No issues found

osx-arm64:
- py3.8:  No issues found
- py3.9:  No issues found
- py3.10:  No issues found

win-64:
- py3.7:  No issues found
- py3.8:  No issues found
- py3.9:  No issues found
- py3.10:  No issues found

</details>

**Package Build Score: 17**


</details>

