### PR TITLE
Bump to 23.11.0.

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "conda-libmamba-solver" %}
-{% set version = "23.9.3" %}
+{% set version = "23.11.0" %}
 
 package:
   name: {{ name }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://github.com/conda/{{ name }}/archive/refs/tags/{{ version }}.tar.gz
-  sha256: 4b573fd9e5f5c5725af7bb08877f2deb5afd79efbe0217ba3f020858e7c40fce
+  sha256: 02d5ebdf5faf0de0bb4b841de2932d7922ec6fca02578a28c63af0853a218012
   folder: src/
 
 build:
@@ -26,7 +26,7 @@ requirements:
   run:
     - python
     - conda >=23.7.4
-    - libmambapy >=1.5.1
+    - libmambapy >=1.5.3
     - boltons >=23.0.0
 
 test:


### PR DESCRIPTION
Release issue: https://github.com/conda/conda-libmamba-solver/issues/350
Release tag: https://github.com/conda/conda-libmamba-solver/releases/tag/23.11.0
Xrefs conda-forge https://github.com/conda-forge/conda-libmamba-solver-feedstock/pull/21