### PR TITLE
Rebuild as noarch

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,20 +11,20 @@ source:
   folder: src/
 
 build:
-  number: 0
-  skip: true  # [py<38]
+  number: 1
+  noarch: python
   script_env:
     - SETUPTOOLS_SCM_PRETEND_VERSION={{version}}
   script: {{ PYTHON }} -m pip install src/ -vv --no-deps --no-build-isolation
 
 requirements:
   host:
-    - python
+    - python >=3.8
     - pip
     - hatchling
     - hatch-vcs
   run:
-    - python
+    - python >=3.8
     - conda >=23.7.4
     - libmambapy >=1.5.3
     - boltons >=23.0.0


### PR DESCRIPTION
conda-libmamba-solver 23.12.0

**Destination channel:** defaults

### Links

- ~ticket_number~
- [Upstream repository](https://github.com/conda/conda-libmamba-solver)
- ~Upstream changelog/diff~
- ~Relevant dependency PRs~

### Explanation of changes:

To resolve circular dependency issue when adding Python 3.12 support to conda.

See https://github.com/conda/conda/actions/runs/7186572269/job/19578481847#step:5:5187
