### PR TITLE
Bump to 24.1.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
   folder: src/
 
 build:
-  number: 1
+  number: 0
   # build as noarch to avoid circular dependency issues in conda when
   # adding support for new Python versions
   noarch: python

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "conda-libmamba-solver" %}
-{% set version = "23.12.0" %}
+{% set version = "24.1.0" %}
 
 package:
   name: {{ name }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://github.com/conda/{{ name }}/archive/refs/tags/{{ version }}.tar.gz
-  sha256: c23210bb5ab81d68ac28ed8f355fe95acc85c246686d4b2ec3924863fc07bb51
+  sha256: 104c4362502507de7dbbf28a0cb522c0204258cefcdd986adb21ea6a7033263d
   folder: src/
 
 build:
@@ -28,7 +28,7 @@ requirements:
   run:
     - python >=3.8
     - conda >=23.7.4
-    - libmambapy >=1.5.3
+    - libmambapy >=1.5.6
     - boltons >=23.0.0
 
 test:


### PR DESCRIPTION
conda-libmamba-solver 24.1.0

**Destination channel:** defaults

https://github.com/conda/conda-libmamba-solver/releases/tag/24.1.0