### PR TITLE
Bump to 24.7.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "conda-libmamba-solver" %}
-{% set version = "24.1.0" %}
+{% set version = "24.7.0" %}
 
 package:
   name: {{ name }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://github.com/conda/{{ name }}/archive/refs/tags/{{ version }}.tar.gz
-  sha256: 104c4362502507de7dbbf28a0cb522c0204258cefcdd986adb21ea6a7033263d
+  sha256: 3eec3df72f7faa3c469b17ea1c540fa47ffc50b751a661bdf22c8e96bfb78abb
   folder: src/
 
 build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -28,7 +28,7 @@ requirements:
   run:
     - python >=3.8
     - conda >=23.7.4
-    - libmambapy >=1.5.6
+    - libmambapy >=1.5.6,<2.0a0
     - boltons >=23.0.0
 
 test:


### PR DESCRIPTION
conda-libmamba-solver 24.7.0

**Destination channel:** defaults

### Links

- {ticket_number}: N/A
- [Upstream repository](https://github.com/conda/conda-libmamba-solver/)
- [Upstream changelog/diff](https://github.com/conda/conda-libmamba-solver/releases/tag/24.7.0)
- Relevant dependency PRs:
  - ...

### Explanation of changes:

- New release
