### PR TITLE
Bump to 24.9.0.

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "conda-libmamba-solver" %}
-{% set version = "24.7.0" %}
+{% set version = "24.9.0" %}
 
 package:
   name: {{ name }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://github.com/conda/{{ name }}/archive/refs/tags/{{ version }}.tar.gz
-  sha256: 3eec3df72f7faa3c469b17ea1c540fa47ffc50b751a661bdf22c8e96bfb78abb
+  sha256: 77a78524719290468665c091cf073f2b97440bfea25c373105a997654063fdbe
   folder: src/
 
 build:


### PR DESCRIPTION
conda-libmamba-solver 24.9.0

**Destination channel:** defaults

### Links

- [PKG-5803](https://anaconda.atlassian.net/browse/PKG-5803) 
- [Upstream repository](https://github.com/conda/conda-libmamba-solver)
- [Upstream changelog/diff](https://github.com/conda/conda-libmamba-solver/releases/tag/24.9.0)

### Explanation of changes:

- Regular maintenance update


[PKG-5803]: https://anaconda.atlassian.net/browse/PKG-5803?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ