### PR TITLE
Update conda-libmamba-solver to 24.11.1

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,4 +1,2 @@
-channels:
-  - https://staging.continuum.io/prefect/fs/mamba-feedstock/pr19/a0008f8
 build_env_vars:
   ANACONDA_ROCKET_ENABLE_PY313 : yes

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,5 +1,4 @@
 channels:
-  - https://staging.continuum.io/prefect/fs/libsolv-feedstock/pr5/9598620
-  - https://staging.continuum.io/prefect/fs/mamba-feedstock/pr19/ab260d3
+  - https://staging.continuum.io/prefect/fs/mamba-feedstock/pr19/a0008f8
 build_env_vars:
   ANACONDA_ROCKET_ENABLE_PY313 : yes

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,5 @@
+channels:
+  - https://staging.continuum.io/prefect/fs/libsolv-feedstock/pr5/9598620
+  - https://staging.continuum.io/prefect/fs/mamba-feedstock/pr19/ab260d3
+build_env_vars:
+  ANACONDA_ROCKET_ENABLE_PY313 : yes

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "conda-libmamba-solver" %}
-{% set version = "24.9.0" %}
+{% set version = "24.11.1" %}
 
 package:
   name: {{ name }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://github.com/conda/{{ name }}/archive/refs/tags/{{ version }}.tar.gz
-  sha256: 77a78524719290468665c091cf073f2b97440bfea25c373105a997654063fdbe
+  sha256: 8a3bfe1c8fb1a2ad599ba0eef31084145dbb105e58ec5a21e06990edec71d035
   folder: src/
 
 build:
@@ -21,14 +21,14 @@ build:
 
 requirements:
   host:
-    - python >=3.8
+    - python >=3.9
     - pip
     - hatchling
     - hatch-vcs
   run:
-    - python >=3.8
-    - conda >=23.7.4
-    - libmambapy >=1.5.6,<2.0a0
+    - python >=3.9
+    - conda >=23.7.3
+    - libmambapy >=2
     - boltons >=23.0.0
 
 test:


### PR DESCRIPTION
conda-libmamba-solver 24.11.1

**Destination channel:** {defaults}

### Links

- [PKG-6359](https://anaconda.atlassian.net/browse/PKG-6359) 
- [Upstream repository](https://github.com/conda/conda-libmamba-solver/tree/24.11.1)
- [Upstream changelog/diff](https://github.com/conda/conda-libmamba-solver/blob/24.11.1/CHANGELOG.md)
- Relevant dependency PRs:
  - https://github.com/AnacondaRecipes/mamba-feedstock/pull/19

### Explanation of changes:

- Update to add compatibility with `libmamba 2.x`


[PKG-6359]: https://anaconda.atlassian.net/browse/PKG-6359?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ