### PR TITLE
Bump to 25.1.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "conda-libmamba-solver" %}
-{% set version = "24.11.1" %}
+{% set version = "25.1.0" %}
 
 package:
   name: {{ name }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://github.com/conda/{{ name }}/archive/refs/tags/{{ version }}.tar.gz
-  sha256: 8a3bfe1c8fb1a2ad599ba0eef31084145dbb105e58ec5a21e06990edec71d035
+  sha256: ff54170a22bf8122ad023649726a10340f74e89160910884c385ed58e548ecca
   folder: src/
 
 build:


### PR DESCRIPTION
conda-libmamba-solver 25.1.0

**Destination channel:** defaults

### Links

- [PKG-6831](https://anaconda.atlassian.net/browse/PKG-6831) 
- [Upstream repository](https://github.com/conda/conda-libmamba-solver)
- [Upstream changelog/diff](https://github.com/conda/conda-libmamba-solver/releases/tag/25.1.0)


[PKG-6831]: https://anaconda.atlassian.net/browse/PKG-6831?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ