### PR TITLE
Bump to 25.3.0.

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "conda-libmamba-solver" %}
-{% set version = "25.1.1" %}
+{% set version = "25.3.0" %}
 
 package:
   name: {{ name }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://github.com/conda/{{ name }}/archive/refs/tags/{{ version }}.tar.gz
-  sha256: 38d8b46d4890b8ebd948b4b2d9761f18d18d6fa4bef87f19bdad0a6f8e5371c8
+  sha256: 1e143b573aff06ee2b96961eaaff389b50e060c15342b44a0ae1def77760ba15
   folder: src/
 
 build:
@@ -27,7 +27,7 @@ requirements:
     - hatch-vcs
   run:
     - python >=3.9
-    - conda >=23.7.3
+    - conda >=23.7.4
     - libmambapy >=2
     - boltons >=23.0.0
 


### PR DESCRIPTION
conda-libmamba-solver 25.3.0

**Destination channel:** defaults

### Links

- [PKG-7405](https://anaconda.atlassian.net/browse/PKG-7405) 
- [Upstream repository](https://github.com/conda/conda-libmamba-solver)
- [Upstream changelog/diff](https://github.com/conda/conda-libmamba-solver/releases/tag/25.3.0)
- Relevant dependency PRs:
  - https://github.com/conda-forge/conda-libmamba-solver-feedstock/pull/38


[PKG-7405]: https://anaconda.atlassian.net/browse/PKG-7405?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ