### PR TITLE
Bump to 25.4.0.

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "conda-libmamba-solver" %}
-{% set version = "25.3.0" %}
+{% set version = "25.4.0" %}
 
 package:
   name: {{ name }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://github.com/conda/{{ name }}/archive/refs/tags/{{ version }}.tar.gz
-  sha256: 1e143b573aff06ee2b96961eaaff389b50e060c15342b44a0ae1def77760ba15
+  sha256: a00bd98681607b1db5783f680e3375931ad990b7d19ae1ebf6987c20330bbfa9
   folder: src/
 
 build:
@@ -27,7 +27,7 @@ requirements:
     - hatch-vcs
   run:
     - python >=3.9
-    - conda >=23.7.4
+    - conda >=24.11
     - libmambapy >=2
     - boltons >=23.0.0
 


### PR DESCRIPTION
conda-libmamba-solver 25.4.0

**Destination channel:** defaults

### Links

- [PKG-8063](https://anaconda.atlassian.net/browse/PKG-8063) 
- [Upstream repository](https://github.com/conda/conda-libmamba-solver)
- [Upstream changelog/diff](https://github.com/conda/conda-libmamba-solver/compare/25.3.0...25.4.0)
- Relevant dependency PRs:
  - https://github.com/conda/conda-libmamba-solver/releases/tag/25.4.0

### Explanation of changes:

- Bumping up the lower bounds of supported conda versions!


[PKG-8063]: https://anaconda.atlassian.net/browse/PKG-8063?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ