### PR TITLE
Bump to 26.4.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "conda-libmamba-solver" %}
-{% set version = "26.3.0" %}
+{% set version = "26.4.0" %}
 
 package:
   name: {{ name }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://github.com/conda/{{ name }}/archive/refs/tags/{{ version }}.tar.gz
-  sha256: 903d9d6873449799b2d4103b43507f8b40101efd8b6a90f8a6318375159a7375
+  sha256: 5762763f554c5174e435c2ac3b25df09221e4fbb9e682506518af34f6a22f4de
   folder: src/
 
 build:


### PR DESCRIPTION
conda-libmamba-solver 26.4.0

**Destination channel:** defaults

### Links

- [PKG-13797](https://anaconda.atlassian.net/browse/PKG-13797) 
- [Upstream repository](https://github.com/conda/conda-libmamba-solver)
- [Upstream changelog/diff](https://github.com/conda/conda-libmamba-solver/blob/main/CHANGELOG.md)
- Relevant dependency PRs: None

### Explanation of changes:

- Sharded repodata is now enabled by default


[PKG-13797]: https://anaconda.atlassian.net/browse/PKG-13797?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ