### PR TITLE
Update to 26.4.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "conda-libmamba-solver" %}
-{% set version = "26.4.0" %}
+{% set version = "26.4.1" %}
 
 package:
   name: {{ name }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://github.com/conda/{{ name }}/archive/refs/tags/{{ version }}.tar.gz
-  sha256: 5762763f554c5174e435c2ac3b25df09221e4fbb9e682506518af34f6a22f4de
+  sha256: f8787d230427361fb16d73d82339fdb27093c1b64e25dedb98bc12fb1903683e
   folder: src/
 
 build:


### PR DESCRIPTION
conda-libmamba-solver 26.4.1

**Destination channel:** defaults

### Links

- [PKG-14488](https://anaconda.atlassian.net/browse/PKG-14488) 
- [Upstream repository](https://github.com/conda/conda-libmamba-solver)
- [Upstream changelog/diff](https://github.com/conda/conda-libmamba-solver/blob/main/CHANGELOG.md)
- Relevant dependency PRs: None

### Explanation of changes:

3 bug fixes, the first is most critical since it was failing some CI runs for us and other users and also showing up for users as well.
- Open the sharded repodata cache (repodata_shards.db) in WAL mode with a longer SQLite busy timeout, so the pipelined cache reader thread no longer races with the network writer: https://github.com/conda/conda-libmamba-solver/pull/926
- Show the target platform instead of the host platform in the progress message during cross-platform lockfile export: https://github.com/conda/conda-libmamba-solver/pull/911
- Fix add_pip_as_python_dependency not being honored when sharded repodata is enabled. https://github.com/conda/conda-libmamba-solver/pull/929

[PKG-14488]: https://anaconda.atlassian.net/browse/PKG-14488?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ