### PR TITLE
Bump to 26.6.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "conda-libmamba-solver" %}
-{% set version = "26.4.2" %}
+{% set version = "26.6.0" %}
 
 package:
   name: {{ name }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://github.com/conda/{{ name }}/archive/refs/tags/{{ version }}.tar.gz
-  sha256: d69a45db04785a1a48d29d98ee4ce6c19147be4703866a23c6b0da1de12b5378
+  sha256: bed1f00dcd0001203aac7f60d8986965b6fbafb4e83ef8c2a4b5a726253172ec
   folder: src/
 
 build:
@@ -28,11 +28,8 @@ requirements:
     - python >=3.10
     - conda >=26.1
     # present in the conda-libmamba-solver recipe file at recipe/meta.yaml but dropped in pyproject.toml because libmambapy is not available on PyPI.
-    - libmambapy >=2
+    - libmambapy >=2.0.0,!=2.6.2
     - boltons >=23.0.0
-    - msgpack-python >=1.1.1
-    - requests >=2.28.0,<3.0.0
-    - zstandard >=0.15
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -26,7 +26,7 @@ requirements:
     - libmambapy {{ libmambapy }}
   run:
     - python >=3.10
-    - conda >=26.1
+    - conda >=26.5
     # present in the conda-libmamba-solver recipe file at recipe/meta.yaml but dropped in pyproject.toml because libmambapy is not available on PyPI.
     - libmambapy >=2.0.0,!=2.6.2
     - boltons >=23.0.0


### PR DESCRIPTION
conda-libmamba-solver 26.6.0

**Destination channel:** defaults

### Links

- [PKG-16093](https://anaconda.atlassian.net/browse/PKG-16093) 
- [Upstream repository](https://github.com/conda/conda-libmamba-solver)
- [Upstream changelog/diff](https://github.com/conda/conda-libmamba-solver/blob/main/CHANGELOG.md)
- Relevant dependency PRs:
  - https://github.com/conda/conda-libmamba-solver/issues/959
  - https://github.com/conda/conda-libmamba-solver/issues/908
  - https://github.com/conda/conda-libmamba-solver/pull/812

### Explanation of changes:

- Moved the sharded repodata shard stock to conda which is there in conda 26.5. conda-libmamba-solver no longer requires related dependencies for network access, msgpack, or zstd.

[PKG-16093]: https://anaconda.atlassian.net/browse/PKG-16093?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ